### PR TITLE
Sanity test fixes

### DIFF
--- a/docs/CVEN_ROLE.md
+++ b/docs/CVEN_ROLE.md
@@ -76,13 +76,13 @@ illumio_cven_container_version=21.5.40-8601
 
 Values for the PCE connection details default to the environment variable values in the table below.  
 
-Variable | Description | Environment variable | Default value
--------- | ----------- | -------------------- | -------------
-`illumio_pce_hostname` | PCE hostname | `ILLUMIO_PCE_HOST` | -
-`illumio_pce_port` | PCE HTTPS port | `ILLUMIO_PCE_PORT` | `443`
-`illumio_pce_org_id` | PCE Organization ID | `ILLUMIO_PCE_ORG_ID` | `1`
-`illumio_pce_api_key` | PCE API key | `ILLUMIO_API_KEY_USERNAME` | -
-`illumio_pce_api_secret` | PCE API secret | `ILLUMIO_API_KEY_SECRET` | -
+Variable | Description | Data Type | Environment variable | Default value
+-------- | ----------- | --------- | -------------------- | -------------
+`illumio_pce_hostname` | PCE hostname | `str` | `ILLUMIO_PCE_HOST` | -
+`illumio_pce_port` | PCE HTTPS port | `int` | `ILLUMIO_PCE_PORT` | `443`
+`illumio_pce_org_id` | PCE Organization ID | `int` | `ILLUMIO_PCE_ORG_ID` | `1`
+`illumio_pce_api_key` | PCE API key | `str` | `ILLUMIO_API_KEY_USERNAME` | -
+`illumio_pce_api_secret` | PCE API secret | `str` | `ILLUMIO_API_KEY_SECRET` | -
 
 ### Kubelink  
 
@@ -92,27 +92,27 @@ See the [Kubelink role docs page](KUBELINK_ROLE.md) for details.
 
 The CVEN secret requires a pairing key that is used to pair the cluster hosts with the PCE. A pairing profile is created (or reused if one with the given name already exists) and used to generate the key for the CVEN secret.  
 
-Variable | Description | Default value
--------- | ----------- | -------------
-`illumio_cven_profile_name` | CVEN pairing profile name | `PP-ANSIBLE-CVEN`
-`illumio_cven_profile_description` | CVEN pairing profile description | `"CVEN cluster host profile. Created by Ansible"`
-`illumio_cven_enforcement_mode` | default enforcement mode for the paired workload. One of `idle`, `visibility_only`, `selective`, or `full` | `idle`
-`illumio_cven_visibility_level` | determines what traffic will be logged by VENs paired with this profile by default. One of `flow_summary`, `flow_drops`, `flow_off`, `enhanced_data_collection` | `flow_summary`
-`illumio_cven_labels` | list of Label HREFs | -
-`illumio_cven_ven_version` | If your PCE's VEN library has multiple versions available, you can specify the version to use. The profile will use the default version configured in the PCE if no value is specified | -
+Variable | Description | Data Type | Default value
+-------- | ----------- | --------- | -------------
+`illumio_cven_profile_name` | CVEN pairing profile name | `str` | `PP-ANSIBLE-CVEN`
+`illumio_cven_profile_description` | CVEN pairing profile description | `str` | `"CVEN cluster host profile. Created by Ansible"`
+`illumio_cven_enforcement_mode` | default enforcement mode for the paired workload. One of `idle`, `visibility_only`, `selective`, or `full` | `str` | `idle`
+`illumio_cven_visibility_level` | determines what traffic will be logged by VENs paired with this profile by default. One of `flow_summary`, `flow_drops`, `flow_off`, `enhanced_data_collection` | `str` | `flow_summary`
+`illumio_cven_labels` | list of Label HREFs | `list` | -
+`illumio_cven_ven_version` | If your PCE's VEN library has multiple versions available, you can specify the version to use. The profile will use the default version configured in the PCE if no value is specified | `str` | -
 
 ### CVEN  
 
 See the Illumio [guide on deploying CVENs](https://docs.illumio.com/core/21.5/Content/Guides/kubernetes-and-openshift/deployment/deploy-c-vens-in-your-cluster.htm) for installation details.  
 
-Variable | Description | Default value
--------- | ----------- | -------------
-`illumio_cven_namespace` | Kubernetes/OpenShift namespace for CVEN config | `illumio-system`  
-`illumio_cven_secret_name` | CVEN Secret name | `illumio-ven-config`  
-`illumio_cven_container_registry` | Container registry the CVEN image will be pulled from. Registry secrets must be set up in Kubernetes/OpenShift independent of this role | -
-`illumio_cven_image_pull_secret` | imagePullSecret name for authentication to a remote image registry | -
-`illumio_cven_container_name` | CVEN container name | `illumio-ven`
-`illumio_cven_container_version` | image tag version to pull | `latest`
+Variable | Description | Data Type | Default value
+-------- | ----------- | --------- | -------------
+`illumio_cven_namespace` | Kubernetes/OpenShift namespace for CVEN config | `str` | `illumio-system`  
+`illumio_cven_secret_name` | CVEN Secret name | `str` | `illumio-ven-config`  
+`illumio_cven_container_registry` | Container registry the CVEN image will be pulled from. Registry secrets must be set up in Kubernetes/OpenShift independent of this role | `str` | -
+`illumio_cven_image_pull_secret` | imagePullSecret name for authentication to a remote image registry | `str` | -
+`illumio_cven_container_name` | CVEN container name | `str` | `illumio-ven`
+`illumio_cven_container_version` | image tag version to pull | `str` | `latest`
 
 > **Note:** if using self-signed or private PKI to sign a host PCE certificate, you will need to update the CVEN DaemonSet to reference the root CA certificate. See [the CVEN deployment documentation](https://docs.illumio.com/core/21.5/Content/Guides/kubernetes-and-openshift/deployment/deploy-c-vens-in-your-cluster.htm#DeployCVENs) for details  
 

--- a/docs/KUBELINK_ROLE.md
+++ b/docs/KUBELINK_ROLE.md
@@ -91,22 +91,22 @@ illumio_kubelink_container_version=2.0.2.d53d7f
 
 Values for the PCE connection details default to the environment variable values in the table below.  
 
-Variable | Description | Environment variable | Default value
--------- | ----------- | -------------------- | -------------
-`illumio_pce_hostname` | PCE hostname | `ILLUMIO_PCE_HOST` | -
-`illumio_pce_port` | PCE HTTPS port | `ILLUMIO_PCE_PORT` | `443`
-`illumio_pce_org_id` | PCE Organization ID | `ILLUMIO_PCE_ORG_ID` | `1`
-`illumio_pce_api_key` | PCE API key | `ILLUMIO_API_KEY_USERNAME` | -
-`illumio_pce_api_secret` | PCE API secret | `ILLUMIO_API_KEY_SECRET` | -
+Variable | Description | Data Type | Environment variable | Default value
+-------- | ----------- | --------- | -------------------- | -------------
+`illumio_pce_hostname` | PCE hostname | `str` | `ILLUMIO_PCE_HOST` | -
+`illumio_pce_port` | PCE HTTPS port | `int` | `ILLUMIO_PCE_PORT` | `443`
+`illumio_pce_org_id` | PCE Organization ID | `int` | `ILLUMIO_PCE_ORG_ID` | `1`
+`illumio_pce_api_key` | PCE API key | `str` | `ILLUMIO_API_KEY_USERNAME` | -
+`illumio_pce_api_secret` | PCE API secret | `str` | `ILLUMIO_API_KEY_SECRET` | -
 
 ### Container Cluster  
 
 By default, a new container cluster with a randomized suffix will be created (e.g. `CC-ANSIBLE-nwfhijpv`). If you would like to use an existing container cluster, you can specify a token along with either the cluster name or cluster ID.  
 
-Variable | Description | Default value
--------- | ----------- | -------------
-`illumio_container_cluster_token` | Container cluster token to store in the Kubelink secret. Must be set if using `illumio_container_cluster_name` | -
-`illumio_container_cluster_name` | Existing container cluster name | -
+Variable | Description | Data Type | Default value
+-------- | ----------- | --------- | -------------
+`illumio_container_cluster_token` | Container cluster token to store in the Kubelink secret. Must be set if using `illumio_container_cluster_name` | `str` | -
+`illumio_container_cluster_name` | Existing container cluster name | `str` | -
 
 ### Kubelink
 
@@ -114,16 +114,16 @@ Variable | Description | Default value
 
 If a Kubelink secret exists in the cluster, Container Cluster creation will be skipped and the existing values will be used for the connection. See the Illumio [guide on deploying Kubelink](https://docs.illumio.com/core/21.5/Content/Guides/kubernetes-and-openshift/deployment/deploy-kubelink-in-your-cluster.htm) for details on the secret file.  
 
-Variable | Description | Default value
--------- | ----------- | -------------
-`illumio_kubelink_namespace` | Kubernetes/OpenShift namespace for Kubelink config | `illumio-system`  
-`illumio_kubelink_secret_name` | Kubelink Secret name | `illumio-kubelink-config`  
-`illumio_kubelink_ignore_cert` | Set to true if using a self-signed certificate for an on-prem PCE | `false`  
-`illumio_kubelink_log_level` | Kubelink log level; `0` for debug, `1` for info, `2` for warn, or `3` for error | `1`
-`illumio_kubelink_container_registry` | Container registry the Kubelink image will be pulled from. Registry secrets must be set up in Kubernetes/OpenShift independent of this role | -
-`illumio_kubelink_image_pull_secret` | imagePullSecret name for authentication to a remote image registry | -
-`illumio_kubelink_container_name` | Kubelink container name | `illumio-kubelink`
-`illumio_kubelink_container_version` | image tag version to pull | `latest`
+Variable | Description | Data Type | Default value
+-------- | ----------- | --------- | -------------
+`illumio_kubelink_namespace` | Kubernetes/OpenShift namespace for Kubelink config | `str` | `illumio-system`  
+`illumio_kubelink_secret_name` | Kubelink Secret name | `str` | `illumio-kubelink-config`  
+`illumio_kubelink_ignore_cert` | Set to true if using a self-signed certificate for an on-prem PCE | `str` | `false`  
+`illumio_kubelink_log_level` | Kubelink log level; `0` for debug, `1` for info, `2` for warn, or `3` for error | `str` | `1`
+`illumio_kubelink_container_registry` | Container registry the Kubelink image will be pulled from. Registry secrets must be set up in Kubernetes/OpenShift independent of this role | `str` | -
+`illumio_kubelink_image_pull_secret` | imagePullSecret name for authentication to a remote image registry | `str` | -
+`illumio_kubelink_container_name` | Kubelink container name | `str` | `illumio-kubelink`
+`illumio_kubelink_container_version` | image tag version to pull | `str` | `latest`
 
 > **Note:** if using self-signed or private PKI to sign a host PCE certificate, you will need to update the Kubelink deployment to reference the root CA certificate. See [the Kubelink deployment documentation](https://docs.illumio.com/core/21.5/Content/Guides/kubernetes-and-openshift/deployment/deploy-kubelink-in-your-cluster.htm#DeployKubelink) for details  
 

--- a/docs/VEN_ROLE.md
+++ b/docs/VEN_ROLE.md
@@ -105,26 +105,26 @@ $ ansible-playbook -i apache_hosts ven_install.yml --tags ven_unpair
 
 Values for the PCE connection details default to the environment variable values in the table below.  
 
-Variable | Description | Environment variable | Default value
--------- | ----------- | -------------------- | -------------
-`illumio_pce_hostname` | PCE hostname | `ILLUMIO_PCE_HOST` | -
-`illumio_pce_port` | PCE HTTPS port | `ILLUMIO_PCE_PORT` | `443`
-`illumio_pce_org_id` | PCE Organization ID | `ILLUMIO_PCE_ORG_ID` | `1`
-`illumio_pce_api_key` | PCE API key | `ILLUMIO_API_KEY_USERNAME` | -
-`illumio_pce_api_secret` | PCE API secret | `ILLUMIO_API_KEY_SECRET` | -
+Variable | Description | Data Type | Environment variable | Default value
+-------- | ----------- | --------- | -------------------- | -------------
+`illumio_pce_hostname` | PCE hostname | `str` | `ILLUMIO_PCE_HOST` | -
+`illumio_pce_port` | PCE HTTPS port | `int` | `ILLUMIO_PCE_PORT` | `443`
+`illumio_pce_org_id` | PCE Organization ID | `int` | `ILLUMIO_PCE_ORG_ID` | `1`
+`illumio_pce_api_key` | PCE API key | `str` | `ILLUMIO_API_KEY_USERNAME` | -
+`illumio_pce_api_secret` | PCE API secret | `str` | `ILLUMIO_API_KEY_SECRET` | -
 
 ### Pairing profile  
 
 VEN pairing requires a key that is used to pair the remote workloads with the PCE. A pairing profile is created (or reused if one with the given name already exists) and used to generate the key used for pairing. If a profile with the given name exists, **its configuration will be overwritten with values provided to the role**.  
 
-Variable | Description | Default value
--------- | ----------- | -------------
-`illumio_ven_profile_name` | pairing profile to use when pairing hosts. If the profile does not exist it will be created. | `PP-ANSIBLE-VEN`
-`illumio_ven_profile_description` | pairing profile description | `"Ansible VEN role pairing profile"`
-`illumio_ven_enforcement_mode` | default enforcement mode for the paired workload. One of `idle`, `visibility_only`, `selective`, or `full` | `idle`
-`illumio_ven_visibility_level` | determines what traffic will be logged by VENs paired with this profile by default. One of `flow_summary`, `flow_drops`, `flow_off`, `enhanced_data_collection` | `flow_summary`
-`illumio_ven_labels` | list of Label HREFs | -
-`illumio_ven_version` | If your PCE's VEN library has multiple versions available, you can specify the version to use. The profile will use the default version configured in the PCE if no value is specified | -
+Variable | Description | Data Type | Default value
+-------- | ----------- | --------- | -------------
+`illumio_ven_profile_name` | pairing profile to use when pairing hosts. If the profile does not exist it will be created. | `str` | `PP-ANSIBLE-VEN`
+`illumio_ven_profile_description` | pairing profile description | `str` | `"Ansible VEN role pairing profile"`
+`illumio_ven_enforcement_mode` | default enforcement mode for the paired workload. One of `idle`, `visibility_only`, `selective`, or `full` | `str` | `idle`
+`illumio_ven_visibility_level` | determines what traffic will be logged by VENs paired with this profile by default. One of `flow_summary`, `flow_drops`, `flow_off`, `enhanced_data_collection` | `str` | `flow_summary`
+`illumio_ven_labels` | list of Label HREFs | `list` | -
+`illumio_ven_version` | If your PCE's VEN library has multiple versions available, you can specify the version to use. The profile will use the default version configured in the PCE if no value is specified | `str` | -
 
 ### Unpair  
 

--- a/plugins/doc_fragments/pce.py
+++ b/plugins/doc_fragments/pce.py
@@ -2,6 +2,9 @@
 
 # Copyright 2022 Illumio, Inc. All Rights Reserved.
 
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 class ModuleDocFragment(object):
 

--- a/plugins/module_utils/pce.py
+++ b/plugins/module_utils/pce.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # Copyright 2022 Illumio, Inc. All Rights Reserved.
@@ -47,7 +46,7 @@ class PceApiBase(object):
 
 
 class PceObjectApi(PceApiBase, metaclass=ABCMeta):
-    _api: PolicyComputeEngine._PCEObjectAPI
+    _api: object
 
     def get_by_href(self, href: str) -> Any:
         try:
@@ -115,13 +114,13 @@ def pce_connection_spec() -> dict:
             fallback=(env_fallback, ['ILLUMIO_PCE_HOST'])
         ),
         pce_port=dict(
-            type='str',
-            default='443',
+            type='int',
+            default=443,
             fallback=(env_fallback, ['ILLUMIO_PCE_PORT'])
         ),
         pce_org_id=dict(
-            type='str',
-            default='1',
+            type='int',
+            default=1,
             fallback=(env_fallback, ['ILLUMIO_PCE_ORG_ID'])
         ),
         api_key_username=dict(

--- a/roles/cven/defaults/main.yml
+++ b/roles/cven/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 # pce connection defaults
 illumio_pce_hostname: "{{ lookup('env', 'ILLUMIO_PCE_HOST') | default(omit) }}"
-illumio_pce_port: "{{ lookup('env', 'ILLUMIO_PCE_PORT') | default('443') }}"
-illumio_pce_org_id: "{{ lookup('env', 'ILLUMIO_PCE_ORG_ID') | default('1') }}"
+illumio_pce_port: "{{ lookup('env', 'ILLUMIO_PCE_PORT') | default('443') | int }}"
+illumio_pce_org_id: "{{ lookup('env', 'ILLUMIO_PCE_ORG_ID') | default('1') | int }}"
 illumio_pce_api_key: "{{ lookup('env', 'ILLUMIO_API_KEY_USERNAME') | default(omit) }}"
 illumio_pce_api_secret: "{{ lookup('env', 'ILLUMIO_API_KEY_SECRET') | default(omit) }}"
 

--- a/roles/kubelink/defaults/main.yml
+++ b/roles/kubelink/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 # pce connection defaults
 illumio_pce_hostname: "{{ lookup('env', 'ILLUMIO_PCE_HOST') | default(omit) }}"
-illumio_pce_port: "{{ lookup('env', 'ILLUMIO_PCE_PORT') | default('443') }}"
-illumio_pce_org_id: "{{ lookup('env', 'ILLUMIO_PCE_ORG_ID') | default('1') }}"
+illumio_pce_port: "{{ lookup('env', 'ILLUMIO_PCE_PORT') | default('443') | int }}"
+illumio_pce_org_id: "{{ lookup('env', 'ILLUMIO_PCE_ORG_ID') | default('1') | int }}"
 illumio_pce_api_key: "{{ lookup('env', 'ILLUMIO_API_KEY_USERNAME') | default(omit) }}"
 illumio_pce_api_secret: "{{ lookup('env', 'ILLUMIO_API_KEY_SECRET') | default(omit) }}"
 

--- a/roles/ven/defaults/main.yml
+++ b/roles/ven/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 # pce connection defaults
 illumio_pce_hostname: "{{ lookup('env', 'ILLUMIO_PCE_HOST') | default(omit) }}"
-illumio_pce_port: "{{ lookup('env', 'ILLUMIO_PCE_PORT') | default('443') }}"
-illumio_pce_org_id: "{{ lookup('env', 'ILLUMIO_PCE_ORG_ID') | default('1') }}"
+illumio_pce_port: "{{ lookup('env', 'ILLUMIO_PCE_PORT') | default('443') | int }}"
+illumio_pce_org_id: "{{ lookup('env', 'ILLUMIO_PCE_ORG_ID') | default('1') | int }}"
 illumio_pce_api_key: "{{ lookup('env', 'ILLUMIO_API_KEY_USERNAME') | default(omit) }}"
 illumio_pce_api_secret: "{{ lookup('env', 'ILLUMIO_API_KEY_SECRET') | default(omit) }}"
 

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -1,0 +1,3 @@
+plugins/modules/container_cluster.py validate-modules:missing-gplv3-license # ignore GPLv3 license checks as we use Apache2.0
+plugins/modules/pairing_key.py validate-modules:missing-gplv3-license
+plugins/modules/pairing_profile.py validate-modules:missing-gplv3-license

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,0 +1,3 @@
+plugins/modules/container_cluster.py validate-modules:missing-gplv3-license # ignore GPLv3 license checks as we use Apache2.0
+plugins/modules/pairing_key.py validate-modules:missing-gplv3-license
+plugins/modules/pairing_profile.py validate-modules:missing-gplv3-license

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,0 +1,3 @@
+plugins/modules/container_cluster.py validate-modules:missing-gplv3-license # ignore GPLv3 license checks as we use Apache2.0
+plugins/modules/pairing_key.py validate-modules:missing-gplv3-license
+plugins/modules/pairing_profile.py validate-modules:missing-gplv3-license

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -1,0 +1,3 @@
+plugins/modules/container_cluster.py validate-modules:missing-gplv3-license # ignore GPLv3 license checks as we use Apache2.0
+plugins/modules/pairing_key.py validate-modules:missing-gplv3-license
+plugins/modules/pairing_profile.py validate-modules:missing-gplv3-license

--- a/tests/utils/render_config_templates.sh
+++ b/tests/utils/render_config_templates.sh
@@ -2,10 +2,12 @@
 
 SRC_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]:-$0}")")
 TESTS_DIR="${SRC_DIR}/.."
-TEMPLATE_FILES=($(find ${TESTS_DIR} -name '*.template' -type f))
+read -r -a TEMPLATE_FILES <<< """$(
+    find "${TESTS_DIR}" -name "*.template" -type f
+)"""
 
 for template in "${TEMPLATE_FILES[@]}"; do
     file=${template%.*}
     content="$(cat "$template")"
-    eval "echo \"$content\"" > $file
+    eval "echo \"$content\"" > "$file"
 done


### PR DESCRIPTION
Fixes issues found with `ansible-test sanity`.

* adds `tests/sanity/ignore-x.x.txt` files to skip license checks for Ansible 2.9+
* updates role defaults to convert PCE port and org_id values to int
  * updates docs to add expected data types for role variables