### PR TITLE
Fix VEN windows compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Python version **3.6** or higher is required for this collection.
 
 **Python**  
 
-For most components, you will need the `illumio` Python library version **1.0.1** or higher installed on **both the local and remote hosts**:
+For most components, you will need the `illumio` Python library version **1.0.1** or higher installed on the local Ansible hosts:  
 
 ```sh
 $ pip install illumio>=1.0.1

--- a/docs/CVEN_ROLE.md
+++ b/docs/CVEN_ROLE.md
@@ -37,7 +37,7 @@ You can install this role with: `ansible-galaxy install illumio.illumio.cven`
 
 ### Requirements  
 
-This module requires Python 3.6+ and the `illumio` python package.  
+This module requires Python 3.6+ and the `illumio` python package installed on the Ansible host.  
 
 The `cven` role depends on the `kubelink` role in order to function - see the `kubelink` [requirements](KUBELINK_ROLE.md#requirements).  
 

--- a/docs/KUBELINK_ROLE.md
+++ b/docs/KUBELINK_ROLE.md
@@ -38,7 +38,7 @@ You can install this role with: `ansible-galaxy install illumio.illumio.kubelink
 
 ### Requirements  
 
-This module requires Python 3.6+ and the `illumio` python package.  
+This module requires Python 3.6+ and the `illumio` python package installed on the Ansible host.  
 
 You must have an existing container repository containing the Kubelink Docker image. See the [Kubelink documentation](https://docs.illumio.com/core/21.5/Content/Guides/kubernetes-and-openshift/deployment/deploy-kubelink-in-your-cluster.htm?Highlight=kubelink) for details.  
 

--- a/docs/VEN_ROLE.md
+++ b/docs/VEN_ROLE.md
@@ -52,7 +52,7 @@ You can install this role with: `ansible-galaxy install illumio.illumio.ven`
 
 ### Requirements  
 
-This module requires Python 3.6+ and the `illumio` python package.  
+This module requires Python 3.6+ and the `illumio` python package installed on the Ansible host.  
 
 In Ansible 2.10 and higher, modules have been moved into collections. Additional collections beyond `ansible.builtin` must now be installed explicitly. For this role, make sure the following collections are installed:  
 

--- a/roles/cven/tasks/main.yml
+++ b/roles/cven/tasks/main.yml
@@ -14,6 +14,7 @@
     labels: "{{ illumio_cven_labels | list }}"
     ven_version: "{{ illumio_cven_ven_version | default(omit) }}"
     state: present
+  delegate_to: '127.0.0.1'
   register: pairing_profile_result
 
 - name: "Generate pairing key"
@@ -24,6 +25,7 @@
     api_key_username: "{{ illumio_pce_api_key }}"
     api_key_secret: "{{ illumio_pce_api_secret }}"
     pairing_profile_href: "{{ pairing_profile_result.pairing_profile['href'] }}"
+  delegate_to: '127.0.0.1'
   register: pairing_key_result
 
 - name: "Set pairing key"

--- a/roles/kubelink/tasks/container_cluster.yml
+++ b/roles/kubelink/tasks/container_cluster.yml
@@ -14,6 +14,7 @@
     name: "{{ illumio_container_cluster_name }}"
     description: Container cluster created by Ansible
     state: present
+  delegate_to: '127.0.0.1'
   register: container_cluster_result
 
 - name: "Fail if cluster token is missing"

--- a/roles/ven/tasks/main.yml
+++ b/roles/ven/tasks/main.yml
@@ -2,9 +2,9 @@
 - name: "Fail on unrecognized system"
   ansible.builtin.fail:
     msg: "Couldn't recognize remote host OS"
-  when: ansible_system != 'Windows' and ansible_system != 'Linux'
+  when: ansible_system != 'Win32NT' and ansible_system != 'Linux'
 
-- name: "VEN | Pair"
+- name: "VEN Pair"
   block:
 
     - include_tasks: pairing_profile.yml
@@ -13,11 +13,17 @@
       when: ansible_system == 'Linux'
 
     - include_tasks: pair_windows.yml
-      when: ansible_system == 'Windows'
+      when: ansible_system == 'Win32NT'
 
   tags:
     - ven_pair
 
-- include_tasks: manage_ven.yml
+- include_tasks: manage_ven_linux.yml
+  when: ansible_system == 'Linux'
+  tags:
+    - always
+
+- include_tasks: manage_ven_windows.yml
+  when: ansible_system == 'Win32NT'
   tags:
     - always

--- a/roles/ven/tasks/manage_ven_linux.yml
+++ b/roles/ven/tasks/manage_ven_linux.yml
@@ -1,0 +1,97 @@
+---
+- name: "Set illumio-ven-ctl path for Linux"
+  ansible.builtin.set_fact:
+    illumio_ven_ctl: /opt/illumio_ven/illumio-ven-ctl
+  tags:
+    - always
+
+- name: "Start VEN"
+  become: yes
+  ansible.builtin.command: "{{ illumio_ven_ctl }} start"
+  register: result
+  changed_when: "'already started' not in result.stdout"
+  tags:
+    - never
+    - ven_start
+
+- name: "Stop VEN"
+  become: yes
+  ansible.builtin.command: "{{ illumio_ven_ctl }} stop"
+  register: result
+  changed_when: "'FAILED' not in result.stdout"
+  tags:
+    - never
+    - ven_stop
+
+- name: "Restart VEN"
+  become: yes
+  ansible.builtin.command: "{{ illumio_ven_ctl }} restart"
+  register: result
+  changed_when: result.rc == 0
+  tags:
+    - never
+    - ven_restart
+
+- name: "Suspend the VEN"
+  become: yes
+  ansible.builtin.command: "{{ illumio_ven_ctl }} suspend"
+  register: result
+  changed_when: "'The VEN has been suspended' in result.stdout"
+  tags:
+    - never
+    - ven_suspend
+
+- name: "Unsuspend VEN"
+  become: yes
+  ansible.builtin.command: "{{ illumio_ven_ctl }} unsuspend"
+  register: result
+  changed_when: "'The VEN has been unsuspended' in result.stdout"
+  tags:
+    - never
+    - ven_unsuspend
+
+- name: "Deactivate VEN"
+  become: yes
+  ansible.builtin.command: "{{ illumio_ven_ctl }} deactivate"
+  register: result
+  changed_when: "'The VEN has been deactivated' in result.stdout"
+  tags:
+    - never
+    - ven_deactivate
+
+- name: "Unpair VEN"
+  become: yes
+  ansible.builtin.command: "{{ illumio_ven_ctl }} unpair {{ illumio_ven_firewall_restore }}"
+  register: result
+  changed_when: result.rc == 0
+  tags:
+    - never
+    - ven_unpair
+
+- name: "Stat VEN control tool"
+  become: yes
+  ansible.builtin.stat:
+    path: "{{ illumio_ven_ctl }}"
+  register: ven_cli
+  tags:
+    - always
+    - ven_status
+
+- name: "Check VEN status"
+  block:
+
+    - name: "Get VEN status"
+      become: yes
+      ansible.builtin.command: "{{ illumio_ven_ctl }} status"
+      failed_when: ven_status.rc > 1
+      register: ven_status
+      changed_when: False
+
+    - name: "Print VEN status"
+      ansible.builtin.debug:
+        msg: "{{ ven_status.stdout_lines }}"
+
+  when: ven_cli.stat.exists
+  tags:
+    - always
+    - ven_status

--- a/roles/ven/tasks/manage_ven_windows.yml
+++ b/roles/ven/tasks/manage_ven_windows.yml
@@ -1,21 +1,13 @@
 ---
-- name: "Set illumio-ven-ctl path for Linux"
-  ansible.builtin.set_fact:
-    illumio_ven_ctl: /opt/illumio_ven/illumio-ven-ctl
-  when: ansible_system == 'Linux'
-  tags:
-    - always
-
 - name: "Set illumio-ven-ctl path for Windows"
   ansible.builtin.set_fact:
     illumio_ven_ctl: C:\Program Files\Illumio\illumio-ven-ctl.ps1
-  when: ansible_system == 'Windows'
   tags:
     - always
 
 - name: "Start VEN"
   become: yes
-  ansible.builtin.command: "{{ illumio_ven_ctl }} start"
+  ansible.windows.win_command: powershell.exe -file "{{ illumio_ven_ctl }}" start
   register: result
   changed_when: "'already started' not in result.stdout"
   tags:
@@ -24,7 +16,7 @@
 
 - name: "Stop VEN"
   become: yes
-  ansible.builtin.command: "{{ illumio_ven_ctl }} stop"
+  ansible.windows.win_command: powershell.exe -file "{{ illumio_ven_ctl }}" stop
   register: result
   changed_when: "'FAILED' not in result.stdout"
   tags:
@@ -33,7 +25,7 @@
 
 - name: "Restart VEN"
   become: yes
-  ansible.builtin.command: "{{ illumio_ven_ctl }} restart"
+  ansible.windows.win_command: powershell.exe -file "{{ illumio_ven_ctl }}" restart
   register: result
   changed_when: result.rc == 0
   tags:
@@ -42,7 +34,7 @@
 
 - name: "Suspend the VEN"
   become: yes
-  ansible.builtin.command: "{{ illumio_ven_ctl }} suspend"
+  ansible.windows.win_command: powershell.exe -file "{{ illumio_ven_ctl }}" suspend
   register: result
   changed_when: "'The VEN has been suspended' in result.stdout"
   tags:
@@ -51,7 +43,7 @@
 
 - name: "Unsuspend VEN"
   become: yes
-  ansible.builtin.command: "{{ illumio_ven_ctl }} unsuspend"
+  ansible.windows.win_command: powershell.exe -file "{{ illumio_ven_ctl }}" unsuspend
   register: result
   changed_when: "'The VEN has been unsuspended' in result.stdout"
   tags:
@@ -60,7 +52,7 @@
 
 - name: "Deactivate VEN"
   become: yes
-  ansible.builtin.command: "{{ illumio_ven_ctl }} deactivate"
+  ansible.windows.win_command: powershell.exe -file "{{ illumio_ven_ctl }}" deactivate
   register: result
   changed_when: "'The VEN has been deactivated' in result.stdout"
   tags:
@@ -69,7 +61,7 @@
 
 - name: "Unpair VEN"
   become: yes
-  ansible.builtin.command: "{{ illumio_ven_ctl }} unpair {{ illumio_ven_firewall_restore }}"
+  ansible.windows.win_command: powershell.exe -file "{{ illumio_ven_ctl }}" unpair {{ illumio_ven_firewall_restore }}
   register: result
   changed_when: result.rc == 0
   tags:
@@ -78,24 +70,28 @@
 
 - name: "Stat VEN control tool"
   become: yes
-  ansible.builtin.stat:
+  ansible.windows.win_stat:
     path: "{{ illumio_ven_ctl }}"
   register: ven_cli
-  tags: always
+  tags:
+    - always
+    - ven_status
 
 - name: "Check VEN status"
   block:
 
     - name: "Get VEN status"
       become: yes
-      ansible.builtin.command: "{{ illumio_ven_ctl }} status"
+      ansible.windows.win_command: powershell.exe -file "{{ illumio_ven_ctl }}" status
       failed_when: ven_status.rc > 1
       register: ven_status
       changed_when: False
 
     - name: "Print VEN status"
       ansible.builtin.debug:
-        var: ven_status.stdout_lines
+        msg: "{{ ven_status.stdout_lines | replace('\\t', ' ') }}"
 
   when: ven_cli.stat.exists
-  tags: always
+  tags:
+    - always
+    - ven_status

--- a/roles/ven/tasks/pair_linux.yml
+++ b/roles/ven/tasks/pair_linux.yml
@@ -1,7 +1,7 @@
 ---
 # Install VEN on Linux
 
-- name: "VEN | Pair | Linux"
+- name: "Pair Linux VEN"
   become: yes
   block:
 

--- a/roles/ven/tasks/pair_windows.yml
+++ b/roles/ven/tasks/pair_windows.yml
@@ -1,10 +1,24 @@
 ---
 # Install VEN on Windows
 
-- name: "VEN | Pair | Windows"
+- name: "Pair Windows VEN"
   become: yes
   ansible.windows.win_powershell:
     script: |
+      param (
+        [String]
+        $PceFqdn,
+
+        [String]
+        $PcePort,
+
+        [String]
+        $PairingProfileId,
+
+        [String]
+        $ActivationCode
+      )
+
       Set-ExecutionPolicy -Scope process remotesigned -Force
 
       Start-Sleep -s 3
@@ -13,11 +27,13 @@
 
       [System.Net.ServicePointManager]::SecurityProtocol=[Enum]::ToObject([System.Net.SecurityProtocolType], 3072)
 
+      [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
       Set-Variable -Name ErrorActionPreference -Value Continue
 
-      (New-Object System.Net.WebClient).DownloadFile('https://$PceFqdn:$PcePort/api/v18/software/ven/image?pair_script=pair.ps1&profile_id=$PairingProfileId', '.\Pair.ps1')
+      (New-Object System.Net.WebClient).DownloadFile("https://$($PceFqdn):$($PcePort)/api/v18/software/ven/image?pair_script=pair.ps1&profile_id=$($PairingProfileId)", "$($env:TEMP)\Pair.ps1")
 
-      .\Pair.ps1  -management-server $PceFqdn:$PcePort -activation-code $ActivationCode
+      & $env:TEMP\Pair.ps1 -management-server ${PceFqdn}:${PcePort} -activation-code ${ActivationCode}
     parameters:
       PceFqdn: "{{ illumio_pce_hostname }}"
       PcePort: "{{ illumio_pce_port }}"

--- a/roles/ven/tasks/pairing_profile.yml
+++ b/roles/ven/tasks/pairing_profile.yml
@@ -15,6 +15,7 @@
     ven_version: "{{ illumio_ven_version | default(omit) }}"
     enabled: yes
     state: present
+  delegate_to: '127.0.0.1'
   register: pairing_profile_result
 
 - name: "Set pairing profile ID"
@@ -29,6 +30,7 @@
     api_key_username: "{{ illumio_pce_api_key }}"
     api_key_secret: "{{ illumio_pce_api_secret }}"
     pairing_profile_name: "{{ illumio_ven_profile_name }}"
+  delegate_to: '127.0.0.1'
   register: pairing_key_result
 
 - name: "Set pairing key"


### PR DESCRIPTION
Fixes issues with VEN pairing and management on Windows remote hosts.

* splits VEN management tasks into separate modules for Linux/Windows
* fixes issues with the powershell script for VEN pairing
* delegates PCE API modules to localhost to work with Windows remotes

- [x] I've read and followed the [contribution guidelines](CONTRIBUTING.md) for this PR  